### PR TITLE
Issue #1 Alternative Solution - Using is_a? instead of string comparison

### DIFF
--- a/lib/jekyll-page-hooks.rb
+++ b/lib/jekyll-page-hooks.rb
@@ -108,7 +108,8 @@ module Jekyll
     end
 
     def is_page?
-      self.is_a? Jekyll::Page
+      self.is_a? Jekyll::Page ||
+      self.class.to_s == 'Octopress::Ink::Page'
     end
 
     def is_convertible_partial?


### PR DESCRIPTION
Here's an attempt to use `is_a?` instead of string comparisons.
